### PR TITLE
feat: add Exception class

### DIFF
--- a/src/ExceptionClass.cpp
+++ b/src/ExceptionClass.cpp
@@ -1,0 +1,99 @@
+#include "ExceptionClass.h"
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+//클래스 정의
+const char * CustomException::getError() const {
+    return error.c_str();
+}
+void CustomException::setError(const string &error) {
+    this->error = error;
+}
+const char * CustomException::what() const noexcept {
+    return this->getError();
+}
+
+CommandException::CommandException(string command) : command(command) {
+    this->setError("명령어 "+command+"(이)가 잘못되었습니다.");
+}
+const string &CommandException::getCommand() const {
+    return this->command;
+}
+
+ArgumentException::ArgumentException(string str) : str(str) {
+    this->setError("인자 "+str+"(이)가 잘못되었습니다.");
+}
+const string &ArgumentException::getStr() const {
+    return this->str;
+}
+
+FileException::FileException() {
+    this->setError("파일에 문제가 있습니다.");
+}
+const string &FileException::getFilePath()const {
+    return this->filepath;
+}
+void FileException::setFilePath(const std::string &path) {
+    this->filepath = path;
+}
+
+UnableCommandException::UnableCommandException(string command, string cmd) : CommandException(command), cmd(cmd) {
+    this->setError("현재 명령창 "+this->cmd+"에서 "+this->getCommand()+"은(는) 사용할 수 없는 명령어입니다.");
+}
+
+WrongCommandException::WrongCommandException(string command) : CommandException(command) {
+    this->setError("명령어 "+this->getCommand()+"은(는) 존재하지 않는 명령어입니다.");
+}
+
+WrongNumArgumentException::WrongNumArgumentException(string command) : ArgumentException(command) {
+    this->setError("명령어 "+this->getStr()+"(이)가 가질 수 있는 인자의 개수와 다릅니다.");
+}
+
+WrongCharArgumentException::WrongCharArgumentException(string argument, char ch) : ArgumentException(argument), ch(ch) {
+    this->setError("입력 인자 "+this->getStr()+"에 사용할 수 없는 문자 \'"+this->ch+"\'(이)가 존재합니다.");
+}
+
+WrongLengthArgumentException::WrongLengthArgumentException(string argument, string length) : ArgumentException(argument), length(length) {
+    this->setError("입력 인자 "+this->getStr().substr(0, 10)+"가 허용 가능한 길이 범위 ["+this->length+"] (을)를 벗어났습니다.");
+}
+
+WrongRuleArgumentException::WrongRuleArgumentException(string argument, string rule) : ArgumentException(argument), rule(rule) {
+    this->setError("입력 인자 "+this->getStr()+"(이)가 의미규칙을 만족하지 못합니다.\n규칙 : "+this->rule);
+}
+
+NotExistFileException::NotExistFileException(string filepath) {
+    this->setFilePath(filepath);
+    this->setError("\'"+this->getFilePath()+"\'"+"(은)는 존재하지 않는 파일입니다.");
+}
+
+WrongFormatFileException::WrongFormatFileException(string filepath) {
+    this->setFilePath(filepath);
+    this->setError("\'"+this->getFilePath()+"\'"+"에 저장된 내용의 형식에 문제가 존재합니다.");
+}
+
+NotExistMetaFileException::NotExistMetaFileException(string filepath) : NotExistFileException(filepath) { }
+
+WrongFormatMetaFileException::WrongFormatMetaFileException(string filepath) : WrongFormatFileException(filepath) { }
+
+
+//메소드 정의
+void exceptionMannager(exception& e){
+    string exceptionName = typeid(e).name();
+    vector<string> helpExceptionList = { typeid(CommandException).name(), typeid(UnableCommandException).name(), typeid(WrongCommandException).name()};
+    vector<string> exitExceptionList = { typeid(FileException).name(), typeid(NotExistMetaFileException).name(), typeid(WrongFormatMetaFileException).name(), typeid(NotExistFileException).name(), typeid(WrongFormatFileException).name()};
+    cout << "[오류] " << exceptionName << " 예외가 발생하였습니다." << endl;
+    cout << e.what() << endl;  // 세부 정보
+
+    auto itHelp = find(helpExceptionList.begin(), helpExceptionList.end(), exceptionName);
+    if (itHelp != helpExceptionList.end()){
+        cout<<"도움말을 출력합니다."<<endl;
+        // help 호출
+    }
+    auto itExit = find(exitExceptionList.begin(), exitExceptionList.end(), exceptionName);
+    if (itExit != exitExceptionList.end()){
+        cout<<"프로그램을 종료합니다."<<endl;
+        exit(EXIT_FAILURE);
+    }
+}

--- a/src/ExceptionClass.h
+++ b/src/ExceptionClass.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <exception>
+#include <string>
+#include <iostream>
+
+using std::string;
+using std::exception;
+
+/*클래스 선언*/
+class CustomException : public exception {
+private:
+    string error = "default error Message";
+public:
+    const char * getError() const;
+    void setError(const string &error);
+    const char * what() const noexcept override;
+};
+
+// 1단계 상속
+class CommandException : public CustomException {   // 생성자 인자 string 1개로 정의
+private:
+    string command;
+public:
+    CommandException(string command);
+    const string &getCommand() const;
+};
+
+class ArgumentException : public CustomException {
+private:
+    string str;
+public:
+    ArgumentException(string str);
+    const string &getStr() const;
+};
+
+class FileException : public CustomException {
+private:
+    string filepath = "filepath"; //기본값
+public:
+    FileException();
+    const string &getFilePath() const;
+    void setFilePath(const string &path);
+};
+
+// 2단계 상속
+class UnableCommandException : public CommandException {
+private:
+    string cmd;
+public:
+    UnableCommandException(string command, string cmd);
+};
+
+class WrongCommandException : public CommandException {
+public:
+    WrongCommandException(string command);
+};
+
+class WrongNumArgumentException : public ArgumentException {
+public:
+    WrongNumArgumentException(string command);
+};
+
+class WrongCharArgumentException : public ArgumentException {
+private:
+    char ch;
+public:
+    WrongCharArgumentException(string argument, char ch);
+};
+
+class WrongLengthArgumentException : public ArgumentException {
+private:
+    string length;
+public:
+    WrongLengthArgumentException(string argument, string length);
+};
+
+class WrongRuleArgumentException : public ArgumentException{
+private:
+    string rule;
+public:
+    WrongRuleArgumentException(string argument, string rule);
+};
+
+class NotExistFileException : public FileException {
+public:
+    NotExistFileException(string filepath);
+};
+
+class WrongFormatFileException : public FileException {
+public:
+    WrongFormatFileException(string filepath);
+};
+
+// 3단계 상속 (File)
+
+class NotExistMetaFileException : public NotExistFileException {
+public:
+    NotExistMetaFileException(string filepath = "meta.txt");
+};
+
+class WrongFormatMetaFileException : public WrongFormatFileException {
+public:
+    WrongFormatMetaFileException(string filepath = "meta.txt");
+};
+
+/*메소드 선언*/
+void exceptionMannager(exception& e);
+//void exceptionMannager(string exceptionName);


### PR DESCRIPTION
## 요약
> 본 프로그램에서 예외를 다루기 위한 기능들을 포함하는 클래스와 관련 헤더파일을 추가하였습니다. 

<br>

## 작업 내용
- C++ 표준 std exception을 상속받는 사용자 정의 예외 클래스를 생성합니다.
- 최상위 예외클래스 exception을 상속받는 클래스는 업캐스팅하여 추후 여러개의 예외를 한번에 처리할 수 있습니다.
- exception에서 클래스의 정보를 반환하는 메소드인 write()를 재정의하여 사용합니다.
- exception의 종류에 따라서 오류메시지를 출력하고, 관련 동작을 수행하는 함수인 exceptionMannager를 정의합니다.
