### PR TITLE
feat: file 입출력 edit v.3

### DIFF
--- a/src/File.cpp
+++ b/src/File.cpp
@@ -34,23 +34,20 @@ vector<vector<string>>File::getAllUsers() {
 		datafile.open(".\\resource\\userdata.txt");
 		if (!datafile.is_open())	throw NotExistFileException("userdata.txt");
 	}
-	catch(exception &e){
+	catch (exception& e) {
 		exceptionMannager(e);
 	}
-	int i = 0;
+	string line;
 	while (1) {
-		string line;
 		getline(datafile, line);
-		if (line == "")
-			break;
+		if (line == "")	break;
 		istringstream iss(line);
 		string str_buf;
+		vector<string> v;
 		while (getline(iss, str_buf, '\t')) {
-			vector<string> v;
-			data.push_back(v);
-			data[i].push_back(str_buf);
+			v.push_back(str_buf);
 		}
-		i++;
+		data.push_back(v);
 	}
 	datafile.close();
 	return  data;		//UserData 전체 return (한 행에 한 명씩)

--- a/src/File.h
+++ b/src/File.h
@@ -4,18 +4,14 @@
 #include<fstream>
 #include<string>
 #include<vector>
-#include<direct.h>	//mkdir
 #include<sstream>
+#include<filesystem>
 
 using namespace std;
+namespace fs = filesystem;
 
 class File
 {
-private:
-
-
-	static vector<vector<string>> readSplit(string path);
-
 public:
 	static void start();
 	static vector<vector<string>>getAllUsers();


### PR DESCRIPTION
## 요약
파일 입출력 클래스 오류 수정본입니다.

## 작업 내용
- 파일을 읽어 벡터에 저장하는 공통 메소드인 readSplit을 제거하였습니다. (파일 스트림 오류를 방지하고 불필요한 예외 처리를 하지 않게)
- getBooking, getUserData, getAllUsers split 후 벡터 저장 과정에서의 알고리즘 오류를 수정하였습니다.
- 파일 open 과정에서의 예외 처리를 추가하였습니다.